### PR TITLE
feat: complex to_real

### DIFF
--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -105,8 +105,11 @@ impl Matrix<f64> {
 }
 
 impl Matrix<c64> {
-    pub fn to_real(&self) -> Matrix<f64> {
-        Matrix::from(self.rows, self.elems.par_iter().map(|e| e.re).collect())
+    pub fn to_real(&self) -> (Matrix<f64>, Matrix<f64>) {
+        (
+            Matrix::from(self.rows, self.elems.par_iter().map(|e| e.re).collect()),
+            Matrix::from(self.rows, self.elems.par_iter().map(|e| e.im).collect()),
+        )
     }
 }
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -29,6 +29,7 @@ pub trait Number:
 {
     fn one() -> Self;
 }
+
 impl Number for f64 {
     fn one() -> Self {
         1.0


### PR DESCRIPTION
複素行列を実行列に変換するメソッド、虚部ごっそり捨ててたけど虚部もタプルとして返すようにした